### PR TITLE
Use openjdk image instead of deprecated java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 # Configuration variables.
 ENV JIRA_HOME     /var/atlassian/jira


### PR DESCRIPTION
Hi,

Official 'java' docker repository has been deprecated.

"This image is officially deprecated in favor of the openjdk image, and will receive no further updates after 2016-12-31 (Dec 31, 2016)."