### PR TITLE
Added Atlassian Crowd SSO integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ RUN set -x \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/logs" \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/temp" \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/work" \
+    && chown daemon:daemon     "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/seraph-config.xml" \
     && sed --in-place          "s/java version/openjdk version/g" "${JIRA_INSTALL}/bin/check-java.sh" \
     && echo -e                 "\njira.home=$JIRA_HOME" >> "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/jira-application.properties" \
-    && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml"
+    && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml" \
+    && touch -d "@0"           "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/seraph-config.xml"
 
 # Use the default unprivileged account. This could be considered bad practice
 # on systems where multiple processes end up being executed by 'daemon' but

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ You can configure a small set of things by supplying the following environment v
 | X_PROXY_PORT           | Sets the Tomcat Connectors `ProxyPort` attribute |
 | X_PROXY_SCHEME         | If set to `https` the Tomcat Connectors `secure=true` and `redirectPort` equal to `X_PROXY_PORT`   |
 | X_PATH                 | Sets the Tomcat connectors `path` attribute |
+| X_CROWD_SSO            | Set to `true` to enable SSO via Atlassian Crowd
+
+## How to enable SSO via Crowd
+
+Setting X_CROWD_SSO to `true` will do two things:
+
+- enable the *SSOSeraphAuthenticator*
+- tell JIRA to load `crowd-properties.conf` from `/var/atlassian/jira` **(It is your responsibility to put it there!)**
+
+**Warning:** You have to setup the Crowd user directory in JIRA beforehand. After enabling the *SSOSeraphAuthenticator*, you are not able to log in using local accounts anymore.
+
+See the [official Documentation](https://confluence.atlassian.com/crowd/integrating-crowd-with-atlassian-jira-192625.html) for more information.
+
 
 ## Contributions
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,4 +18,12 @@ if [ "$(stat -c "%Y" "${JIRA_INSTALL}/conf/server.xml")" -eq "0" ]; then
   fi
 fi
 
+if [ "$(stat -c "%Y" "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/seraph-config.xml")" -eq "0" ]; then
+  if [ "${X_CROWD_SSO}" = "true" ]; then
+    xmlstarlet ed --inplace -u "/security-config/authenticator[@class='com.atlassian.jira.security.login.JiraSeraphAuthenticator']/@class" -v "com.atlassian.jira.security.login.SSOSeraphAuthenticator" "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/seraph-config.xml"
+    export CATALINA_OPTS="${CATALINA_OPTS} -Dcrowd.properties=${JIRA_HOME}/crowd.properties"
+  fi
+fi
+
+
 exec "$@"


### PR DESCRIPTION
The will enable login via Crowd SSO.
When X_CROWD_SSO is set to true, the default authenticator implementation will be changed to SSOSeraphAuthenticator. Also, -Dcrowd.properties=${JIRA_HOME}/crowd.properties is appended to CATALINA_OPTS