### PR TITLE
Force use of Jira Software V8.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-alpine
 # Configuration variables.
 ENV JIRA_HOME     /var/atlassian/jira
 ENV JIRA_INSTALL  /opt/atlassian/jira
-ENV JIRA_VERSION  8.1.0
+ENV JIRA_VERSION  8.0.2
 
 # Install Atlassian JIRA and helper tools and setup initial home
 # directory structure.
@@ -14,7 +14,7 @@ RUN set -x \
     && chmod -R 700            "${JIRA_HOME}" \
     && chown -R daemon:daemon  "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_INSTALL}/conf/Catalina" \
-    && curl -Ls                "https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.13.3.tar.gz" | tar -xz --directory "${JIRA_INSTALL}" --strip-components=1 --no-same-owner \
+    && curl -Ls                "https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-${JIRA_VERSION}.tar.gz" | tar -xz --directory "${JIRA_INSTALL}" --strip-components=1 --no-same-owner \
     && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz" | tar -xz --directory "${JIRA_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar" \
     && rm -f                   "${JIRA_INSTALL}/lib/postgresql-9.1-903.jdbc4-atlassian-hosted.jar" \
     && curl -Ls                "https://jdbc.postgresql.org/download/postgresql-42.2.1.jar" -o "${JIRA_INSTALL}/lib/postgresql-42.2.1.jar" \

--- a/bin/prepare
+++ b/bin/prepare
@@ -6,23 +6,23 @@
 # VERSION. If no VERSION information is specified the latest version is
 # retrieved from the Atlassian JIRA download feed.
 
-if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ] && [ -z "$1" ]; then
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ] then
 	echo "Not master branch and therefore nothing to prepare"
 	exit 0
-elif [ -n "${1}" ]; then
-	echo "Overriding latest Atlassian JIRA to ${1}"
 fi
 
 echo "Obtaining Altassian JIRA version information..."
 
+JIRA_ENV_RE="ENV JIRA_VERSION[[:space:]]*(.+)"
+
 # Obtain the currently latest version of Atlassian JIRA version defined by the
 # Dockerfile in this repository.
-CURRENT_VERSION=$(sed -nr 's/ENV JIRA_VERSION[[:space:]]*(.+)/\1/p' Dockerfile)
+CURRENT_VERSION=$(sed -nr "s/${JIRA_ENV_RE}/\1/p" Dockerfile)
 
 # Obtain the latest Atlassian JIRA version by going to the JSON version feed
 # information to get a JSONP formatted response, strip the output to retrieve
 # the actual content and then get the version number from the first entry.
-curl -Ls 'https://my.atlassian.com/download/feeds/current/jira-software.json' | sed 's/downloads(\(.*\))/\1/g' | jq -r '.[] | select(.description | test("TAR\\.GZ Archive")) | ("" + .zipUrl + " " + .version)' | while read -r URL VERSION
+curl -Ls 'https://my.atlassian.com/download/feeds/current/jira-software.json' | sed 's/downloads(\(.*\))/\1/g' | jq -r '.[] | select(.description | test("TAR\\.GZ Archive")) | select(.zipUrl | test("software-8")) | .version' | while read -r VERSION
 do
 
 	echo "Found versions:"
@@ -32,12 +32,9 @@ do
 
 	echo "Preparing branch for version new Atlassian JIRA version"
 
-
 	# Edit the `Dockerfile` by changing the current version to the new obtained
 	# version from the Atlassian JIRA version feed.
-	sed --in-place "s/${CURRENT_VERSION}/${VERSION}/g" Dockerfile
-	NAME="${URL#https://www.atlassian.com/software/jira/downloads/binary/}"
-	sed --in-place "s/atlassian-jira-software-.*.tar.gz/${NAME}/g" Dockerfile
+        sed --in-place -r "s/${JIRA_ENV_RE}/ENV JIRA_VERSION  ${VERSION}/g" Dockerfile
 
 	echo "Ready for acceptance testing"
 


### PR DESCRIPTION
Fixes: #61 

Updated prepare script to explicitly pull the V8.x version of the Atlassian Software tarball. Removed unused script parameter and forced the Dockerfile to use the environmental variable to pull the code rather than having to update it in place

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.